### PR TITLE
Add eggs to PYTHONPATH instead of parent dir.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,0 +1,10 @@
+install() {
+  default_install
+
+  # Inject a sitecustomize.py that allows .pth files to be interpreted.
+  # Required for setuptools >= 49.
+  cat <<EOF > "$PYDEST/sitecustomize.py"
+import site
+site.addsitedir("$PYDEST")
+EOF
+}


### PR DESCRIPTION
The `easy-install.pth` file is ineffective in a PYTHONPATH directory that is not part of the `site-packages` site customization startup, so we have to add the egg files explicitly.  These will need to be changed when the upstream tarball is updated.

In addition, implement SIM-1636 that was marked as done without any actual change.