### PR TITLE
Use relative rather than absolute path in sitecustomize.py.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -4,7 +4,8 @@ install() {
   # Inject a sitecustomize.py that allows .pth files to be interpreted.
   # Required for setuptools >= 49.
   cat <<EOF > "$PYDEST/sitecustomize.py"
+import os
 import site
-site.addsitedir("$PYDEST")
+site.addsitedir(os.path.dirname(__file__))
 EOF
 }


### PR DESCRIPTION
This allows the build and install paths to be different (as for Jenkins-built tarballs).