### PR TITLE
Added python_extinction to sncosmo.table setupRequired list.

### DIFF
--- a/ups/sncosmo.table
+++ b/ups/sncosmo.table
@@ -1,4 +1,5 @@
 setupRequired(astropy_helpers)
+setupRequired(python_extinction)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
somehow python_extinction wasn't in the table list before, but is required .. and yet it worked. But now it doesn't. 
It's mysterious. This ought to fix things. 